### PR TITLE
fixing missing 'CREDENTIALS_FOLDER' error when starting verifier backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,4 @@ ISSUER_PORT=3001
 
 #verifier
 VERIFIER_BASE_URL=http://localhost:3002
+CREDENTIALS_FOLDER=templates

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,7 +100,6 @@ services:
       - DB_TYPE=sqlite
       - DB_NAME=data/db.sqlite
       - KM_FOLDER=data
-      - CREDENTIALS_FOLDER=templates
     volumes:
       - issuer_tmp:/home/node/app/data:rw
       - ./config/issuer-backend:/home/node/app/templates


### PR DESCRIPTION
fixes one out of three errors found in #55 