### PR TITLE
feat(nx-cloud): setup nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -17,10 +17,7 @@
       "{workspaceRoot}/.github/workflows/cd.yml"
     ]
   },
-  "workspaceLayout": {
-    "appsDir": "apps",
-    "libsDir": "libs"
-  },
+  "workspaceLayout": { "appsDir": "apps", "libsDir": "libs" },
   "plugins": [
     {
       "plugin": "@nx/vite/plugin",
@@ -40,29 +37,17 @@
         "previewTargetName": "preview"
       }
     },
-    {
-      "plugin": "@nx/eslint/plugin",
-      "options": {
-        "targetName": "lint"
-      }
-    },
+    { "plugin": "@nx/eslint/plugin", "options": { "targetName": "lint" } },
     {
       "plugin": "@nx/jest/plugin",
-      "options": {
-        "targetName": "test"
-      },
+      "options": { "targetName": "test" },
       "exclude": [
         "apps/issuer-backend-e2e/**/*",
         "apps/verifier-backend-e2e/**/*",
         "apps/holder-backend-e2e/**/*"
       ]
     },
-    {
-      "plugin": "@nx/playwright/plugin",
-      "options": {
-        "targetName": "e2e"
-      }
-    }
+    { "plugin": "@nx/playwright/plugin", "options": { "targetName": "e2e" } }
   ],
   "targetDefaults": {
     "@angular-devkit/build-angular:application": {
@@ -93,13 +78,8 @@
       "style": "scss",
       "unitTestRunner": "jest"
     },
-    "@nx/angular:library": {
-      "linter": "eslint",
-      "unitTestRunner": "jest"
-    },
-    "@nx/angular:component": {
-      "style": "scss",
-      "skipTests": true
-    }
-  }
+    "@nx/angular:library": { "linter": "eslint", "unitTestRunner": "jest" },
+    "@nx/angular:component": { "style": "scss", "skipTests": true }
+  },
+  "nxCloudAccessToken": "ZDI5YjgxN2MtMzcxZS00ZTVjLWJhOTItYWZiMGM5MGIzM2U5fHJlYWQtd3JpdGU="
 }

--- a/nx.json
+++ b/nx.json
@@ -81,5 +81,5 @@
     "@nx/angular:library": { "linter": "eslint", "unitTestRunner": "jest" },
     "@nx/angular:component": { "style": "scss", "skipTests": true }
   },
-  "nxCloudAccessToken": "ZDI5YjgxN2MtMzcxZS00ZTVjLWJhOTItYWZiMGM5MGIzM2U5fHJlYWQtd3JpdGU="
+  "nxCloudAccessToken": "OTRjZWVlYTktMDI5OS00MTUzLWE4YWEtMWEzZDYwZTFkNzc5fHJlYWQ="
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 
    
This commit set up Nx Cloud for your Nx workspace enabling distributed caching
and GitHub integration for fast CI and improved Developer Experience.

You can access your Nx Cloud workspace by going to 
https://cloud.nx.app/orgs/66d892f59d8f2a9508fbb837/workspaces/66d893079afc0a2de49bb514

**Note:** This commit attempts to maintain formatting of the nx.json, however you may need to correct formatting by running an nx format command and committing the changes.